### PR TITLE
Big sur shm readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ You can do the following to run with ./scripts/run.sh:
     kern.sysv.shmseg=32
     kern.sysv.shmall=4096
     ```
+    
+    For Mac Big Sur or after, the setting in `/etc/sysctl.conf` would be **deprecated**, therefore, we can use alternative way to set up shm.
+    Copy `memory.plist` daemon to `/Library/LaunchDaemons` then reboot
+    ```sh
+    sudo cp memory.plist /Library/LaunchDaemons/memory.plist
+    ```
+
 * Check that we do have 16M shared-mem
     ```
     sysctl -a|grep shm

--- a/memory.plist
+++ b/memory.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>Label</key>
+ <string>shmemsetup</string>
+ <key>UserName</key>
+ <string>root</string>
+ <key>GroupName</key>
+ <string>wheel</string>
+ <key>ProgramArguments</key>
+ <array>
+  <string>/usr/sbin/sysctl</string>
+  <string>-w</string>
+  <string>kern.sysv.shmmax=16777216</string>
+  <string>kern.sysv.shmmin=1</string>
+  <string>kern.sysv.shmmni=128</string>
+  <string>kern.sysv.shmseg=32</string>
+  <string>kern.sysv.shmall=4096</string>
+ </array>
+ <key>KeepAlive</key>
+ <false/>
+ <key>RunAtLoad</key>
+ <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## 這個 PR 的目的 / Purpose of this PR
主要是更新README有關於 MacOS SHM 設定的部分，因為在新版OS (BigSur)，設定 `/etc/sysctl.conf` 的方法失效了，所以參考了[此篇](https://dansketcher.com/2021/03/30/shmmax-error-on-big-sur/)的方法進行了更新

主要是在 `LaunchDaemon`內新增一個新的 `plist` daemon, 檔案部分可以參考 [memory.plist](https://github.com/cftang0827/go-pttbbs/blob/big-sur-shm-readme/memory.plist)

經過重開機以後，這樣的修改會是持續的
## 相關的 issue / Related Issues
N/A
