### PR TITLE
follow-up-252

### DIFF
--- a/api/is_boards_valid_user_test.go
+++ b/api/is_boards_valid_user_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/Ptt-official-app/go-pttbbs/bbs"
@@ -44,8 +45,11 @@ func TestIsBoardsValidUser(t *testing.T) {
 			expectedResult: expected1,
 		},
 	}
+	var wg sync.WaitGroup
 	for _, tt := range tests {
+		wg.Add(1)
 		t.Run(tt.name, func(t *testing.T) {
+			defer wg.Done()
 			gotResult, err := IsBoardsValidUser(tt.args.remoteAddr, tt.args.uuserID, tt.args.params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsBoardsValidUser() error = %v, wantErr %v", err, tt.wantErr)
@@ -55,5 +59,6 @@ func TestIsBoardsValidUser(t *testing.T) {
 				t.Errorf("IsBoardsValidUser() = %v, want %v", gotResult, tt.expectedResult)
 			}
 		})
+		wg.Wait()
 	}
 }

--- a/api/reload_uhash.go
+++ b/api/reload_uhash.go
@@ -16,8 +16,7 @@ func ReloadUHashWrapper(c *gin.Context) {
 }
 
 func ReloadUHash(remoteAddr string, uuserID bbs.UUserID, params interface{}) (result interface{}, err error) {
-	userID, _ := uuserID.ToRaw()
-	err = bbs.ReloadUHash(userID)
+	err = bbs.ReloadUHash(uuserID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/reload_uhash_test.go
+++ b/api/reload_uhash_test.go
@@ -5,20 +5,12 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Ptt-official-app/go-pttbbs/ptt"
-
-	"github.com/Ptt-official-app/go-pttbbs/ptttype"
-
 	"github.com/Ptt-official-app/go-pttbbs/bbs"
 )
 
 func TestReloadUHash(t *testing.T) {
 	setupTest(t.Name())
 	defer teardownTest(t.Name())
-	userID1 := ptttype.UserID_t{}
-	copy(userID1[:], []byte("SYSOP"))
-	uID, user, _ := ptt.InitCurrentUser(&userID1)
-	_, _ = ptt.SetUserPerm(user, uID, user, ptttype.PERM_SYSOP)
 
 	type args struct {
 		remoteAddr string

--- a/bbs/reload_uhash.go
+++ b/bbs/reload_uhash.go
@@ -6,13 +6,20 @@ import (
 	"github.com/Ptt-official-app/go-pttbbs/ptttype"
 )
 
-func ReloadUHash(userID *ptttype.UserID_t) (err error) {
-	userLevel, err := ptt.GetUserLevel(userID)
+func ReloadUHash(uuserID UUserID) (err error) {
+	userIDRaw, err := uuserID.ToRaw()
 	if err != nil {
 		return err
 	}
-	if userLevel.HasUserPerm(ptttype.PERM_SYSOP) {
-		return cache.LoadUHash()
+
+	_, userecRaw, err := ptt.InitCurrentUser(userIDRaw)
+	if err != nil {
+		return err
 	}
-	return ErrInvalidPermission
+
+	if !userecRaw.UserLevel.HasUserPerm(ptttype.PERM_SYSOP) {
+		return ErrInvalidPermission
+	}
+
+	return cache.LoadUHash()
 }

--- a/bbs/reload_uhash_test.go
+++ b/bbs/reload_uhash_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/Ptt-official-app/go-pttbbs/ptt"
-
-	"github.com/Ptt-official-app/go-pttbbs/ptttype"
 )
 
 func TestReloadUHash(t *testing.T) {
@@ -17,18 +15,8 @@ func TestReloadUHash(t *testing.T) {
 	_ = ptt.SetupNewUser(testPermissionUserecRaw2)
 	_ = ptt.SetupNewUser(testPermissionUserecRaw3)
 
-	// setup test case 1: For test, should be work
-	userID1 := ptttype.UserID_t{}
-	copy(userID1[:], []byte("test"))
-	// setup test case 2: For test1, should NOT be work
-	userID2 := ptttype.UserID_t{}
-	copy(userID2[:], []byte("test1"))
-	// setup test case 3: For test2, should NOT be work
-	userID3 := ptttype.UserID_t{}
-	copy(userID3[:], []byte("test2"))
-
 	type args struct {
-		userID *ptttype.UserID_t
+		userID UUserID
 	}
 	tests := []struct {
 		name    string
@@ -37,17 +25,17 @@ func TestReloadUHash(t *testing.T) {
 	}{
 		{
 			name:    "For SYSOP, should be work",
-			args:    args{userID: &userID1},
+			args:    args{userID: "test"},
 			wantErr: false,
 		},
 		{
 			name:    "For A1, should NOT be work (0)",
-			args:    args{userID: &userID2},
+			args:    args{userID: "test1"},
 			wantErr: true,
 		},
 		{
 			name:    "For test, should NOT be work (ptttype.PERM_BOARD | ptttype.PERM_POST | ptttype.PERM_LOGINOK)",
-			args:    args{userID: &userID3},
+			args:    args{userID: "test2"},
 			wantErr: true,
 		},
 	}

--- a/ptt/bbs_test.go
+++ b/ptt/bbs_test.go
@@ -105,8 +105,8 @@ func TestReadPost(t *testing.T) {
 				t.Errorf("ReadPost() gotMtime = %v, want %v", gotMtime, tt.expectedMtime)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestNewPost(t *testing.T) {

--- a/ptt/board_list_test.go
+++ b/ptt/board_list_test.go
@@ -37,7 +37,6 @@ func TestLoadGeneralBoards(t *testing.T) {
 
 	logrus.Infof("bsorted (by-class): %v", bsorted)
 
-	// move setupTest in for-loop
 	type args struct {
 		user     *ptttype.UserecRaw
 		uid      ptttype.UID
@@ -148,8 +147,8 @@ func TestLoadGeneralBoards(t *testing.T) {
 
 			testutil.TDeepEqual(t, "nextSummary", gotNextSummary, tt.expectedNextSummary)
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestLoadBoardSummary(t *testing.T) {
@@ -196,8 +195,8 @@ func TestLoadBoardSummary(t *testing.T) {
 
 			testutil.TDeepEqual(t, "summary", gotSummary, tt.expectedSummary)
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestLoadHotBoards(t *testing.T) {
@@ -249,8 +248,8 @@ func TestLoadHotBoards(t *testing.T) {
 				t.Errorf("LoadHotBoards() = %v, want %v", gotSummary, tt.expectedSummary)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestLoadBoardsByBids(t *testing.T) {
@@ -293,8 +292,8 @@ func TestLoadBoardsByBids(t *testing.T) {
 				t.Errorf("LoadBoardsByBids() = %v, want %v", gotSummaries, tt.expectedSummaries)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestFindBoardStartIdxByName(t *testing.T) {
@@ -334,8 +333,8 @@ func TestFindBoardStartIdxByName(t *testing.T) {
 				t.Errorf("FindBoardStartIdxByName() = %v, want %v", gotStartIdx, tt.expectedStartIdx)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestFindBoardStartIdxByClass(t *testing.T) {
@@ -376,8 +375,8 @@ func TestFindBoardStartIdxByClass(t *testing.T) {
 				t.Errorf("FindBoardStartIdxByClass() = %v, want %v", gotStartIdx, tt.expectedStartIdx)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestLoadAutoCompleteBoards(t *testing.T) {

--- a/ptt/board_test.go
+++ b/ptt/board_test.go
@@ -48,8 +48,8 @@ func Test_boardPermStatNormally(t *testing.T) {
 				t.Errorf("boardPermStatNormally() = %v, want %v", got, tt.expected)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestIsBoardValidUser(t *testing.T) {
@@ -95,8 +95,8 @@ func TestIsBoardValidUser(t *testing.T) {
 				t.Errorf("IsBoardValidUser() = %v, want %v", gotIsValid, tt.expectedIsValid)
 			}
 		})
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func TestNewBoard(t *testing.T) {

--- a/ptt/passwd_test.go
+++ b/ptt/passwd_test.go
@@ -240,8 +240,11 @@ func Test_pwcuLoginSave(t *testing.T) {
 			wantLastHost:          ptttype.IPv4_t{56, 46, 56, 46, 56, 46, 56},
 		},
 	}
+	var wg sync.WaitGroup
 	for _, tt := range tests {
+		wg.Add(1)
 		t.Run(tt.name, func(t *testing.T) {
+			defer wg.Done()
 			gotIsFirstLoginOfDay, err := pwcuLoginSave(tt.args.uid, tt.args.user, tt.args.ip)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("pwcuLoginSave() error = %v, wantErr %v", err, tt.wantErr)
@@ -257,5 +260,6 @@ func Test_pwcuLoginSave(t *testing.T) {
 				t.Errorf("pwcuLoginSave() gotLastHost = %v, want %v", tt.args.user.LastHost, tt.wantLastHost)
 			}
 		})
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
* by convention, userID.ToRaw should be in bbs/ layer.
* use ptt.InitCurrentUser because of some special user-permission setup for SYSOP

## 這個 PR 的目的 / Purpose of this PR

## 相關的 issue / Related Issues

#252 