### PR TITLE
Delete article Update API Response from Indexes to ArticleIDs

### DIFF
--- a/api/delete_articles.go
+++ b/api/delete_articles.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/Ptt-official-app/go-pttbbs/bbs"
-	"github.com/Ptt-official-app/go-pttbbs/ptttype"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,7 +16,7 @@ type DeleteArticlesPath struct {
 }
 
 type DeleteArticlesResult struct {
-	Indexes []ptttype.SortIdx `json:"indexes"`
+	ArticleIDs []bbs.ArticleID `json:"aids"`
 }
 
 func DeleteArticlesWrapper(c *gin.Context) {
@@ -41,5 +40,5 @@ func DeleteArticles(remoteAddr string, uuserID bbs.UUserID, params interface{}, 
 	if err != nil {
 		return nil, err
 	}
-	return DeleteArticlesResult{Indexes: result.([]ptttype.SortIdx)}, nil
+	return DeleteArticlesResult{ArticleIDs: result.([]bbs.ArticleID)}, nil
 }

--- a/api/delete_articles_test.go
+++ b/api/delete_articles_test.go
@@ -95,7 +95,7 @@ func TestDeleteArticles(t *testing.T) {
 				params0,
 				path0,
 			},
-			DeleteArticlesResult{Indexes: []ptttype.SortIdx{1}},
+			DeleteArticlesResult{ArticleIDs: []bbs.ArticleID{bbs.ToArticleID(filename0)}},
 			false,
 		},
 	}

--- a/bbs/delete_articles.go
+++ b/bbs/delete_articles.go
@@ -2,10 +2,9 @@ package bbs
 
 import (
 	"github.com/Ptt-official-app/go-pttbbs/ptt"
-	"github.com/Ptt-official-app/go-pttbbs/ptttype"
 )
 
-func DeleteArticles(uuserID UUserID, bboardID BBoardID, articleIDs []ArticleID, ip string) ([]ptttype.SortIdx, error) {
+func DeleteArticles(uuserID UUserID, bboardID BBoardID, articleIDs []ArticleID, ip string) ([]ArticleID, error) {
 	userIDRaw, err := uuserID.ToRaw()
 	if err != nil {
 		return nil, err
@@ -21,7 +20,7 @@ func DeleteArticles(uuserID UUserID, bboardID BBoardID, articleIDs []ArticleID, 
 		return nil, err
 	}
 
-	var result []ptttype.SortIdx
+	var result []ArticleID
 	for _, articleID := range articleIDs {
 		filename := articleID.ToFilename()
 		createTime, err := filename.CreateTime()
@@ -38,11 +37,10 @@ func DeleteArticles(uuserID UUserID, bboardID BBoardID, articleIDs []ArticleID, 
 			articleSummary := NewArticleSummaryFromRaw(bboardID, summariesRaw[0])
 			if articleID == articleSummary.ArticleID {
 				err = ptt.DeleteArticles(boardIDRaw, filename, startIdx)
-				// TODO is need recover deleted items if get error?
 				if err != nil {
 					return nil, err
 				}
-				result = append(result, startIdx)
+				result = append(result, articleID)
 			}
 		}
 	}

--- a/bbs/delete_articles.go
+++ b/bbs/delete_articles.go
@@ -20,7 +20,7 @@ func DeleteArticles(uuserID UUserID, bboardID BBoardID, articleIDs []ArticleID, 
 		return nil, err
 	}
 
-	var result []ArticleID
+	result := make([]ArticleID, 0, len(articleIDs))
 	for _, articleID := range articleIDs {
 		filename := articleID.ToFilename()
 		createTime, err := filename.CreateTime()

--- a/bbs/delete_articles_test.go
+++ b/bbs/delete_articles_test.go
@@ -75,7 +75,7 @@ func TestDeleteArticles(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		results []ptttype.SortIdx
+		results []ArticleID
 		wantErr bool
 	}{
 		{
@@ -86,7 +86,7 @@ func TestDeleteArticles(t *testing.T) {
 				articleIDs: []ArticleID{ToArticleID(filename0)},
 				ip:         "127.0.0.1",
 			},
-			results: []ptttype.SortIdx{1},
+			results: []ArticleID{ToArticleID(filename0)},
 			wantErr: false,
 		},
 		{
@@ -97,7 +97,7 @@ func TestDeleteArticles(t *testing.T) {
 				articleIDs: []ArticleID{ToArticleID(filename1)},
 				ip:         "127.0.0.1",
 			},
-			results: []ptttype.SortIdx{2},
+			results: []ArticleID{ToArticleID(filename1)},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
## 這個 PR 的目的 / Purpose of this PR

for https://github.com/Ptt-official-app/go-openbbsmiddleware/issues/253

在 go-openbbsmiddleware 中必須要同步刪除 db 中的資料，不過由於 go-pttbbs 的 api 是允許大量刪除的

所以在 go-openbbsmiddleware 那邊得到的 response 必須要清楚知道是哪一個 article 成功被刪除

之前回傳的是文章在看板中的 index ，沒辦法幫忙識別那一個文章有成功被刪除，因此修改了 api's response 

## 相關的 issue / Related Issues
