### PR TITLE
PttLock with Whence as io.SeekStart

### DIFF
--- a/cmsys/lock.go
+++ b/cmsys/lock.go
@@ -18,7 +18,7 @@ func pttLock(file *os.File, offset int64, theSize uintptr, mode int) (err error)
 	fd := file.Fd()
 
 	lock_it := &syscall.Flock_t{
-		Whence: int16(io.SeekCurrent),
+		Whence: int16(io.SeekStart),
 		Start:  offset,
 		Len:    int64(theSize),
 		Type:   int16(mode),


### PR DESCRIPTION
Based on:

https://github.com/ptt/pttbbs/pull/101

we should change PttLock with Whence as io.SeekStart

## 這個 PR 的目的 / Purpose of this PR

## 相關的 issue / Related Issues
